### PR TITLE
fix: enable basic auth for scm so we can do git push

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 apiappname=WeatherDataAPI$(openssl rand -hex 5)
 
-printf "Setting username and password for Git ... (1/7)\n\n"
+printf "Setting username and password for Git ... (1/8)\n\n"
 
 
 GIT_USERNAME=gitName$Random
@@ -17,23 +17,28 @@ az group create --location eastus --name learn-apim-rg
 PLAN_NAME=myPlan
 
 
-printf "\nCreating App Service plan in FREE tier ... (2/7)\n\n"
+printf "\nCreating App Service plan in FREE tier ... (2/8)\n\n"
 
 
 az appservice plan create --name $apiappname --resource-group learn-apim-rg --location centralus --sku FREE --verbose
 
-printf "\nCreating API App ... (3/7)\n\n"
+printf "\nCreating API App ... (3/8)\n\n"
 
 az webapp create --name $apiappname --resource-group learn-apim-rg --plan $apiappname --deployment-local-git --verbose
 
 
-printf "\nSetting the account-level deployment credentials ...(4/7)\n\n"
+printf "\nSetting the account-level deployment credentials ...(4/8)\n\n"
 
 
 DEPLOY_USER="myName1$(openssl rand -hex 5)"
 DEPLOY_PASSWORD="Pw1$(openssl rand -hex 10)"
 
 az webapp deployment user set --user-name $DEPLOY_USER --password $DEPLOY_PASSWORD --verbose
+
+printf "\nEnabling SCM Basic Authentication for Git publishing ...(5/8)\n\n"
+
+az resource update --resource-group learn-apim-rg --name scm --namespace Microsoft.Web --resource-type basicPublishingCredentialsPolicies --parent sites/$apiappname --set properties.allow=true
+
 
 
 GIT_URL="https://$DEPLOY_USER@$apiappname.scm.azurewebsites.net/$apiappname.git"
@@ -44,19 +49,19 @@ REMOTE_NAME=production
 
 
 # Set remote on src
-printf "\nSetting Git remote...(5/7)\n\n"
+printf "\nSetting Git remote...(6/8)\n\n"
 
 
 git remote add $REMOTE_NAME $GIT_URL
 
 
-printf "\nGit add...(6/7)\n\n"
+printf "\nGit add...(7/8)\n\n"
 
 git add .
 git commit -m "initial revision"
 
 
-printf "\nGit push... (7/7)\n\n"
+printf "\nGit push... (8/8)\n\n"
 
 
 # printf "When prompted for a password enter this: $DEPLOY_PASSWORD\n"


### PR DESCRIPTION
This pull request updates the deployment setup script to add a new step for enabling SCM Basic Authentication for Git publishing, and adjusts the step numbering throughout the script to reflect this addition.

Deployment process improvements:

* Added a new step to enable SCM Basic Authentication for Git publishing using the `az resource update` command.
* Updated all step numbering and related messages 
* Resolves: https://github.com/MicrosoftDocs/mslearn-control-authentication-with-apim/issues/6

@microsoft-github-policy-service agree